### PR TITLE
Fix the type of the days-back option

### DIFF
--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -584,11 +584,11 @@ def main():
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    stop = opt.stop
+    stop = DateTime(opt.stop)
     if opt.start is None:
-        start = DateTime() - opt.days_back
+        start = DateTime(-opt.days_back)
     else:
-        start = opt.start
+        start = DateTime(opt.start)
 
     # these globals are cop-outs but ...
     global ACQ_STATS

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -586,7 +586,7 @@ def main():
 
     stop = DateTime(opt.stop)
     if opt.start is None:
-        start = DateTime(-opt.days_back)
+        start = DateTime() - opt.days_back
     else:
         start = DateTime(opt.start)
 

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -47,6 +47,7 @@ def get_options():
                         help="stop time for search for manvrs for report")
     parser.add_argument("--days-back",
                         default=10,
+                        type=int,
                         help="number of days back from 'now' for standard report (default 10)")
     opt = parser.parse_args()
     return opt

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -47,7 +47,7 @@ def get_options():
                         help="stop time for search for manvrs for report")
     parser.add_argument("--days-back",
                         default=10,
-                        type=int,
+                        type=float,
                         help="number of days back from 'now' for standard report (default 10)")
     opt = parser.parse_args()
     return opt


### PR DESCRIPTION
Fix the type of the days-back option to fix

```
TypeError: unsupported operand type(s) for -: 'float' and 'str'
```
for `--days-back 90`.

It is a different question about if use of the implicit strategy of `--start=-14` would be more maintainable, but this is helpful for now.