### PR TITLE
Update task_schedule.cfg

### DIFF
--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -1,7 +1,7 @@
 # Configuration file for task_schedule.pl to run astromon jobs
 
 subject           ACA weekly report
-timeout           1000              # Default tool timeout
+timeout           7200              # Default tool timeout
 heartbeat_timeout 10                # Maximum age of heartbeat file (seconds)
 iterations        1                 # Run once then shut down task_schedule
 print_error       1                 # Print full log of errors

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -19,7 +19,7 @@ master_log   report.log             # Composite master log (created in log_dir)
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
-alert       jeanconn@head.cfa.harvard.edu
+alert       aca@head.cfa.harvard.edu
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -38,6 +38,16 @@ alert       jeanconn@head.cfa.harvard.edu
 
 <task aca_weekly_report>
       cron       * * * * *
+      check_cron * * * * *
       exec aca_weekly_report --out=$ENV{SKA}/www/ASPECT/aca_weekly_report
       exec aca_weekly_report --out=$ENV{SKA}/www/ASPECT/aca_weekly_report/quarter --days-back 90
+      <check>
+        <error>
+          #    File            Expression
+          #  -------------     ---------------------------
+             aca_weekly_report.log     error
+             aca_weekly_report.log     warning
+             aca_weekly_report.log     fatal
+        </error>
+      </check>
 </task>


### PR DESCRIPTION
Update task_schedule.cfg

- [x] watch cron logs with a check section
- [x] send complaints to aca
- [x] increase timeout (the 90 day part can take a bit; the plan is this is temporary until there is a better system to roll over weeks/reports)