### PR TITLE
Fix warning for obsid 0 at 2023:044

### DIFF
--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -269,7 +269,9 @@ def get_kalman_data(manvr):
     kalman_data = {'consec_lt_two': 0,
                    'min_kalstr': np.nan}
     trange = get_time_range('AOKALSTR')
-    if manvr.get_next() is False or trange[1] < DateTime(manvr.get_next().start).secs:
+    if (manvr.guide_start is None
+        or manvr.get_next() is False
+            or trange[1] < DateTime(manvr.get_next().start).secs):
         return kalman_data
     dat = fetch_sci.Msidset(['AOKALSTR', 'AOPCADMD', 'AOACASEQ'],
                             manvr.guide_start,
@@ -625,7 +627,7 @@ def main():
             metric_rows.append(metric_row)
             markups.append(markup)
         except Exception:
-            logger.warn(f"Skip {manvr.obsid} at {manvr.start}.  Error processing")
+            logger.warning(f"Skip {manvr.obsid} at {manvr.start}.  Error processing")
 
     markups = Table(markups)
     metric_print = vstack(metric_rows)


### PR DESCRIPTION
## Description

Don't calculate Kalman metrics for observations with maneuvers that don't have guide_start defined.

Fixes warning for obsid 0 at 2023:044

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Removes warning output: "ERROR - line 1: Skip 0 at 2023:044:17:27:33.526.  Error processing"
