### PR TITLE
Set weekly report to use ska_dbi Sqsh for fid stats

### DIFF
--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -137,7 +137,7 @@ def get_fid_data(pcat):
     """
     if len(pcat.fids) == 0:
         return []
-    with Sqsh(dbi='sybase', server='sybase', user='aca_read') as db:
+    with Sqsh(dbi='sybase', server='sybase', database='aca', user='aca_read') as db:
         fids = db.fetchall(
             f"select * from trak_stats_data where obsid = {pcat.obsid} and type = 'FID'")
     if len(fids) > 0:

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -15,7 +15,7 @@ from astropy.table import Table, join, vstack
 from collections import defaultdict
 import logging
 
-import Ska.DBI
+from ska_dbi.sqsh import Sqsh
 from Chandra.Time import DateTime
 import kadi.paths
 from kadi import events
@@ -137,7 +137,7 @@ def get_fid_data(pcat):
     """
     if len(pcat.fids) == 0:
         return []
-    with Ska.DBI.DBI(dbi='sybase', server='sybase', user='aca_read') as db:
+    with Sqsh(dbi='sybase', server='sybase', user='aca_read') as db:
         fids = db.fetchall(
             f"select * from trak_stats_data where obsid = {pcat.obsid} and type = 'FID'")
     if len(fids) > 0:


### PR DESCRIPTION
## Description

Set weekly report to use ska_dbi.sqsh for reading the fid light track stats from sybase database.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Requires https://github.com/sot/ska_dbi/pull/25 

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Output for standard arguments written to https://icxc.cfa.harvard.edu/aspect/test_review_outputs/aca_weekly_report-pr13/ .  This qualitatively matches what I see at https://cxc.cfa.harvard.edu/mta/ASPECT/aca_weekly_report/ .
