### PR TITLE
Fixes for new centroid reports and fid data

### DIFF
--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -598,13 +598,16 @@ def make_metric_print(dat, warn_map):  # noqa: PLR0912 too many branches
     print_table["load"] = f"<A HREF='{dat['starcheck']}'>{dat['load_name']}</A>"
     print_table["obsid"] = f"<A HREF='{dat['detail_url']}'>{dat['obsid']}</A>"
     print_table["mica"] = f"<A HREF='{dat['mica']}'>mica</A>"
-    print_table["dash"] = f"<A HREF='{dat['dash']}'>dash</A>" if dat["dash"] is not None else ""
+    print_table["dash"] = (
+        f"<A HREF='{dat['dash']}'>dash</A>" if dat["dash"] is not None else ""
+    )
     print_table["start"] = dat["start"]
 
     # Add the rest
     for col in print_cols:
-        print_table[col] = f"{dat[col]:{formats[col]}}" if col in formats else str(dat[col])
-
+        print_table[col] = (
+            f"{dat[col]:{formats[col]}}" if col in formats else str(dat[col])
+        )
 
     print_table = Table([print_table])
     print_table["warns"] = href_warns

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -243,7 +243,10 @@ def get_max_tccd(start, stop):
     if stop is None or DateTime(stop).secs > get_time_range("AACCCDPT")[1]:
         return np.nan
     else:
-        return np.max(fetch_sci.Msid("AACCCDPT", start, stop).vals)
+        t_ccd = fetch_sci.Msid("AACCCDPT", start, stop)
+        if t_ccd is None or len(t_ccd.vals) == 0:
+            return np.nan
+        return np.max(t_ccd.vals)
 
 
 def get_manvr_data(manvr):
@@ -300,6 +303,8 @@ def get_kalman_data(manvr):
     dat = fetch_sci.Msidset(
         ["AOKALSTR", "AOPCADMD", "AOACASEQ"], manvr.guide_start, manvr.get_next().start
     )
+    if len(dat["AOKALSTR"].vals) == 0:
+        return kalman_data
     dat.interpolate(1.025)
     ok = (dat["AOACASEQ"].vals == "KALM") & (dat["AOPCADMD"].vals == "NPNT")
     kalman_data["min_kalstr"] = np.min(dat["AOKALSTR"].vals[ok].astype(int))

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -244,7 +244,7 @@ def get_max_tccd(start, stop):
         return np.nan
     else:
         t_ccd = fetch_sci.Msid("AACCCDPT", start, stop)
-        if t_ccd is None or len(t_ccd.vals) == 0:
+        if len(t_ccd.vals) == 0:
             return np.nan
         return np.max(t_ccd.vals)
 
@@ -604,18 +604,13 @@ def make_metric_print(dat, warn_map):  # noqa: PLR0912 too many branches
     print_table["load"] = f"<A HREF='{dat['starcheck']}'>{dat['load_name']}</A>"
     print_table["obsid"] = f"<A HREF='{dat['detail_url']}'>{dat['obsid']}</A>"
     print_table["mica"] = f"<A HREF='{dat['mica']}'>mica</A>"
-    if dat["dash"] is not None:
-        print_table["dash"] = f"<A HREF='{dat['dash']}'>dash</A>"
-    else:
-        print_table["dash"] = ""
+    print_table["dash"] = f"<A HREF='{dat['dash']}'>dash</A>" if dat["dash"] is not None else ""
     print_table["start"] = dat["start"]
 
     # Add the rest
     for col in print_cols:
-        if col in formats:
-            print_table[col] = f"{dat[col]:{formats[col]}}"
-        else:
-            print_table[col] = str(dat[col])
+        print_table[col] = f"{dat[col]:{formats[col]}}" if col in formats else str(dat[col])
+
 
     print_table = Table([print_table])
     print_table["warns"] = href_warns


### PR DESCRIPTION
## Description

Fixes for new centroid reports and fid data.

The new centroid reports have a different structure, so this updates the weekly report URL to use the modern url if it exists and otherwise links to the old reports.

The sybase fid data is deprecated so this PR also uses the new fid drop data table from ska_trend.fid_drop_mon .

There's also a few tiny fixes to deal with missing data on day 2025:163.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Output for a long chunk (to go back to the last fid drop) at 

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/aca_weekly_report/pr18/
