### PR TITLE
Handle > 160 one shots without skipping

### DIFF
--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -241,6 +241,16 @@ def get_max_tccd(start, stop):
         return np.max(t_ccd.vals)
 
 
+def _get_p_man_err(one_shot, man_angle):
+    """
+    Get the probability of a one shot of the given size for the given maneuver angle.
+
+    This is a helper function to get around the fact that get_p_man_err is not defined
+    for one_shot > 160.
+    """
+    return get_p_man_err(one_shot, man_angle) if one_shot <= 160 else 0.0001
+
+
 def get_manvr_data(manvr):
     """
     Calculate likelihood of a one shot from proseco's get_p_man_err.
@@ -251,7 +261,7 @@ def get_manvr_data(manvr):
     :param manvr: kadi manvr to the dwell being reported upon
     :returns: dictionary with maneuver observed quantities and probability of one shot size
     """
-    p_man_err_before = get_p_man_err(manvr.one_shot, manvr.angle)
+    p_man_err_before = _get_p_man_err(manvr.one_shot, manvr.angle)
     if manvr.get_next() is False:
         one_shot_after = -1
         man_angle_after = -1
@@ -259,7 +269,7 @@ def get_manvr_data(manvr):
     else:
         one_shot_after = manvr.get_next().one_shot
         man_angle_after = manvr.get_next().angle
-        p_man_err_after = get_p_man_err(one_shot_after, man_angle_after)
+        p_man_err_after = _get_p_man_err(one_shot_after, man_angle_after)
     return {
         "man angle before": manvr.angle,
         "one shot before": manvr.one_shot,

--- a/aca_weekly_report/report.py
+++ b/aca_weekly_report/report.py
@@ -246,7 +246,7 @@ def _get_p_man_err(one_shot, man_angle):
     Get the probability of a one shot of the given size for the given maneuver angle.
 
     This is a helper function to get around the fact that get_p_man_err is not defined
-    for one_shot > 160.
+    for one_shot > 160.  For one_shot > 160, this just returns 0.0001.
     """
     return get_p_man_err(one_shot, man_angle) if one_shot <= 160 else 0.0001
 


### PR DESCRIPTION
## Description

Handle one shots larger than allowed from proseco's get_p_man_err function.
Internally, this just assigns p=0.0001 for > 160 one shots.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes
```
/proj/sot/ska3/aca/data/aca_weekly_report/logs/aca_weekly_report.log
** ERROR - line 1: Skip 32288 at 2026:098:02:37:06.286.  Error processing
** ERROR - line 2: Skip 30152 at 2026:098:06:08:11.185.  Error processing
** ERROR - line 3: Skip 32288 at 2026:098:02:37:06.286.  Error processing
** ERROR - line 4: Skip 30152 at 2026:098:06:08:11.185.  Error processing
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran this locally and it no longer skipped 32288 (183 arcsec one shot after) and 30152 (has the 183 arcsec one shot).
